### PR TITLE
ToDo: unistall ast completely

### DIFF
--- a/astpk.py
+++ b/astpk.py
@@ -17,6 +17,7 @@ args = list(sys.argv)
 # Clean up code, add more comments to code.
 # Add documentation, improve /etc merges (currently unhandled), make the tree sync write less data maybe?
 # Maybe port for other distros?
+# A clean way to completely unistall ast
 # -----------------
 
 # Directories


### PR DESCRIPTION
with no traces behind. Any software installation should come with a proper un-installation.

The code clean-up and folder unification of ast can help in easier uninstallation.